### PR TITLE
Update CI/CD workflow to use HTTP for health check accessibility test

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -577,7 +577,7 @@ jobs:
             
             # Test HTTP accessibility before getting SSL
             echo "🔍 Testing HTTP accessibility..."
-            if curl -f --connect-timeout 10 --max-time 30 https://queentrack.online/health > /dev/null 2>&1; then
+            if curl -f --connect-timeout 10 --max-time 30 http://queentrack.online/health > /dev/null 2>&1; then
               echo "✅ HTTP site is accessible"
               
               # Get SSL certificate


### PR DESCRIPTION
- Changed health check URL in the CI/CD workflow from HTTPS to HTTP to ensure proper testing of site accessibility before SSL acquisition.
- This adjustment aims to enhance the reliability of the health check process during deployment.