### PR TITLE
Fix nginx location ordering - exact matches before prefix matches

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -99,14 +99,14 @@ http {
             add_header Content-Type text/plain;
         }
 
-        # Test endpoints for debugging
-        location /api/test-connection {
+        # Specific API test endpoint (must come before /api/)
+        location = /api/test-connection {
             return 200 "Nginx proxy is working. Testing backend at 162.55.53.52:8000";
             add_header Content-Type text/plain;
         }
         
         # Direct backend test endpoint (bypass prefix stripping)
-        location /backend-test {
+        location = /backend-test {
             proxy_pass http://162.55.53.52:8000/health;
             add_header X-Debug-Direct-Test "Testing direct connection to backend /health" always;
             proxy_set_header Host $host;
@@ -116,7 +116,7 @@ http {
         }
         
         # Test backend root endpoint to see what's actually running
-        location /backend-root-test {
+        location = /backend-root-test {
             proxy_pass http://162.55.53.52:8000/;
             add_header X-Debug-Root-Test "Testing backend root endpoint" always;
             proxy_set_header Host $host;
@@ -125,7 +125,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # API proxy with debugging
+        # API proxy with debugging (less specific, comes after exact matches)
         location /api/ {
             # Add debug headers
             add_header X-Debug-Original-URI $request_uri always;


### PR DESCRIPTION
Fix nginx location ordering - exact matches before prefix matches